### PR TITLE
Missing Tables improvments & New config option to specify listening adress

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Screenshots taken from private version
     "HOST": "example.com or localhost/127.0.0.1",
     "SUBDIR": "/skinsExample/ or just /",
     "PORT": 27275,
+    "INTERNAL_HOST": "127.0.0.1 [Or if you know what are you doing and need it. Use 0.0.0.0 for all interfaces.]",
     "STEAMAPIKEY": "Your Steam Web API Key",
     "SESSION_SECRET": "Some random and secure string containing letters, numbers and special characters like !@#$%^&*(). Atleast 32 chars long.",
     "connect": {

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Screenshots taken from private version
     "HOST": "example.com or localhost/127.0.0.1",
     "SUBDIR": "/skinsExample/ or just /",
     "PORT": 27275,
-    "INTERNAL_HOST": "127.0.0.1 [Or if you know what are you doing and need it. Use 0.0.0.0 for all interfaces.]",
+    "INTERNAL_HOST": "127.0.0.1 [For advanced use cases and users only. Read notes.]",
     "STEAMAPIKEY": "Your Steam Web API Key",
     "SESSION_SECRET": "Some random and secure string containing letters, numbers and special characters like !@#$%^&*(). Atleast 32 chars long.",
     "connect": {
@@ -59,6 +59,8 @@ Screenshots taken from private version
 ```
 
 - Make sure the database that you specified in the config is the same as in the WeaponPaints plugin. Otherwise the needed tables won't exist and the website won't work.
+
+- If you are running in docker or running some special server setup. You might encounter issues with the internal expressjs server. As its default running on 127.0.0.1. If you need to change this. You can do so via config option **`INTERNAL_HOST`** and set it to whatever interface you need. For most advanced use cases like reverse proxy 0.0.0.0 can be used.
 
 - Supported languages **`ru, en, pt-BR`**
 

--- a/src/app.js
+++ b/src/app.js
@@ -14,7 +14,6 @@ const lang = require(`./lang/${config.lang}.json`)
 
 const app = new express()
 
-const PORT = config.PORT
 const DBTables = ["wp_player_agents", "wp_player_gloves", "wp_player_knife", "wp_player_music","wp_player_skins"]
 
 let returnURL = `${config.PROTOCOL}://${config.HOST}${config.SUBDIR}api/auth/steam/return`
@@ -39,11 +38,19 @@ connection.connect(function(err){
     }
     else{
         console.log("Connected to MySQL!\nRunning table check...");
-        connection.query(`SELECT COUNT(table_name) AS table_count FROM information_schema.tables WHERE table_schema = ? AND table_name IN (?)`, [config.DB.DB_DB, DBTables], (err, results, fields) => {
-            if (results[0].table_count < DBTables.length) {
-                throw new Error("Check failed! - Needed database tables are missing!")
-            } else {
+        connection.query(`SELECT table_name FROM information_schema.tables WHERE table_schema = ? AND table_name IN (?)`, [config.DB.DB_DB, DBTables], (err, results, fields) => {
+            let tables = results.map(result => result.table_name);
+            let missingTables = [];
+
+            if (tables.length === 0) throw new Error("Check failed! - No tables found!")
+            
+            DBTables.forEach(StaticTable => {
+                if (!tables.includes(StaticTable)) missingTables.push(StaticTable); 
+            });
+            if (missingTables.length === 0) {
                 console.log("Check OK! - All tables are present!")
+            } else {
+                throw new Error("Check failed! - Needed database tables are missing!"+missingTables.map(missingTable => `\nMissing Table: ${missingTable}`))
             }
         })
     }
@@ -146,8 +153,8 @@ if (config.SUBDIR != '/') {
 }
 
 // start server
-const server = app.listen(PORT, () => {
-    console.log(`App is running on http://localhost:${PORT}`)
+const server = app.listen(config.PORT, config.INTERNAL_HOST, () => {
+    console.log(`App is running on http://localhost:${config.PORT}`)
 })
 
 // initialize socket.io

--- a/src/app.js
+++ b/src/app.js
@@ -154,7 +154,7 @@ if (config.SUBDIR != '/') {
 
 // start server
 const server = app.listen(config.PORT, config.INTERNAL_HOST, () => {
-    console.log(`App is running on http://localhost:${config.PORT}`)
+    console.log(`App is running on http://${(config.INTERNAL_HOST === undefined)? "localhost": config.INTERNAL_HOST}:${config.PORT}`)
 })
 
 // initialize socket.io

--- a/src/config.example.json
+++ b/src/config.example.json
@@ -11,6 +11,7 @@
     "HOST": "example.com or localhost/127.0.0.1",
     "PROTOCOL": "https",
     "PORT": 27275,
+    "INTERNAL_HOST": "127.0.0.1",
     "STEAMAPIKEY": "Your Steam Web API Key",
     "SESSION_SECRET": "Some random and secure string containing letters, numbers and special characters like !@#$%^&*(). Atleast 32 chars long.",
     "connect": {


### PR DESCRIPTION
This pull request introduces a set of small changes that improve and might come in handy later.

- **Missing Tables Feature** The check now throws the error alongside a list of missing tables
- **New Config option** I have added **`INTERNAL_HOST`** config option that allows users to specify on what IP the want the internal ExpressJs server running on. This will be useful for advanced users running a reverse proxy or some type of special setup.

